### PR TITLE
spec/audit-log: add 'ai' actor + optional aiAssisted field

### DIFF
--- a/spec/audit-log.md
+++ b/spec/audit-log.md
@@ -47,7 +47,7 @@ Every entry is a JSON object with these fields:
 ### Required fields
 
 - **`ts`** — ISO 8601 UTC timestamp with millisecond precision. Example: `"2026-04-07T14:32:11.123Z"`. Implementations MUST use UTC.
-- **`actor`** — one of `"owner"`, `"ca"`, or `"system"`. Identifies the category of actor that performed the action.
+- **`actor`** — one of `"owner"`, `"ca"`, `"system"`, or `"ai"`. Identifies the category of actor that performed the action. The value `"ai"` indicates an entry that was drafted by an on-device or remote AI suggestion and explicitly accepted by a human; AI is never a sole actor — see "AI-assisted entries" below.
 - **`action`** — a dotted identifier for the action type. See "Action types" below.
 - **`hash`** — SHA-256 hash forming the chain. See "Hash chain" below. Format: `"sha256:"` followed by 64 lowercase hex characters.
 
@@ -58,6 +58,7 @@ Every entry is a JSON object with these fields:
 - **`ref`** — identifier of the affected entity (invoice number, customer ID, etc.). Shape depends on action type.
 - **`changes`** — for edit actions, a diff showing what changed. Shape depends on action type.
 - **`reason`** — free-text explanation supplied by the user. Always optional.
+- **`aiAssisted`** — boolean. Set to `true` when an entry was drafted by an AI suggestion and accepted by a human actor. Most commonly appears alongside `actor: "ca"` (a CA accepting an AI-drafted entry); for owner-mode AI accepts, `actor: "ai"` is used directly and `aiAssisted` is not set. Implementations MAY omit this field; absence means `false`. See "AI-assisted entries" below.
 - Additional action-specific fields are permitted; implementations should preserve unknown fields on read and write them back unchanged.
 
 ---
@@ -173,6 +174,20 @@ When signing is used:
 - The keypair uses Ed25519 (recommended) or ECDSA P-256
 - Signing is applied to the hash chain, not to individual entries
 - Signature rotation (new keypair) is logged as a `keypair.rotate` action with the new public key
+
+---
+
+## AI-assisted entries
+
+Format version 1.0 recognises that some implementations may surface AI-drafted entry forms (e.g., extracting line items from an uploaded vendor bill, or composing a voucher from natural-language input). The format takes a position on how these entries are recorded:
+
+1. **AI is never an actor on its own.** A human always accepts an AI-drafted entry before it is posted; the audit log records the human acceptance, not the AI proposal.
+2. **`actor: "ai"`** is used when an owner-mode user accepts an AI-drafted entry. The AI is the proximate cause of the entry's contents; the owner is the consenting party.
+3. **`actor: "ca"` + `aiAssisted: true`** is used when a CA in CA-mode accepts an AI-drafted entry. The CA remains the accountable actor; the boolean flag preserves the AI-assist provenance.
+4. **AI prompts are not logged.** Only the accepted entry is logged. The natural-language prompt, the extracted OCR text, and any rejected drafts MUST NOT appear in the audit log payload — they often contain sensitive financial context and add no forensic value beyond the accepted entry.
+5. **No AI-specific fields beyond `aiAssisted`.** Implementations MUST NOT add fields like `aiProvider`, `aiModel`, `aiConfidence`, etc. to the audit-log payload at format version 1.0. These are useful for debugging in implementation memory but are not part of the format's forensic surface.
+
+The hash chain treats the new actor value and the optional `aiAssisted` field exactly like any other actor or payload field — they participate in canonical-JSON serialization and signing without special-casing.
 
 ---
 


### PR DESCRIPTION
## Why

Bahi's reference implementation is starting work on Smart Capture (v1.1) — a small set of AI-drafted entry surfaces (bill ingest, text-to-entry, voice-to-entry) where the user reviews and accepts a draft before the existing posting bridge fires. Nothing AI-originated ever auto-posts; the AI only proposes, the user always confirms.

For audit forensics we need to be able to tell, looking at any audit-log entry, whether the human keyed it by hand or accepted an AI-drafted form. The `actor` field is the natural place — it already distinguishes `"owner"`, `"ca"`, and `"system"`.

This PR is **advisory** — it proposes a small, additive shape and is happy to be revised. Bahi can build against the proposed shape locally and reconcile to whatever you accept.

## What changes

### 1. `actor` enum gains a fourth value

The `actor` field description in [`spec/audit-log.md`](spec/audit-log.md) currently reads:

> **`actor`** — one of `"owner"`, `"ca"`, or `"system"`. Identifies the category of actor that performed the action.

After this PR:

> **`actor`** — one of `"owner"`, `"ca"`, `"system"`, or `"ai"`. Identifies the category of actor that performed the action. The value `"ai"` indicates an entry that was drafted by an on-device or remote AI suggestion and explicitly accepted by a human; AI is never a sole actor — see "AI-assisted entries" below.

### 2. New optional `aiAssisted` payload field

When a CA accepts an AI-drafted entry, the `actor` stays as `"ca"` (because the CA is the human accountable for the books) and the entry payload carries a new optional boolean `aiAssisted: true`. This keeps CA-mode and CA-mode-with-AI-assist distinguishable without inflating the actor enum.

Added to the "Optional fields" list:

> **`aiAssisted`** — boolean. Set to `true` when an entry was drafted by an AI suggestion and accepted by a human actor. Most commonly appears alongside `actor: "ca"` (a CA accepting an AI-drafted entry); for owner-mode AI accepts, `actor: "ai"` is used directly and `aiAssisted` is not set. Implementations MAY omit this field; absence means `false`.

### 3. New short subsection: "AI-assisted entries"

Inserted between "Signing" and "Origin tracking":

> ## AI-assisted entries
>
> Format version 1.0 recognises that some implementations may surface AI-drafted entry forms (e.g., extracting line items from an uploaded vendor bill, or composing a voucher from natural-language input). The format takes a position on how these entries are recorded:
>
> 1. **AI is never an actor on its own.** A human always accepts an AI-drafted entry before it is posted; the audit log records the human acceptance, not the AI proposal.
> 2. **`actor: "ai"`** is used when an owner-mode user accepts an AI-drafted entry. The AI is the proximate cause of the entry's contents; the owner is the consenting party.
> 3. **`actor: "ca"` + `aiAssisted: true`** is used when a CA in CA-mode accepts an AI-drafted entry. The CA remains the accountable actor; the boolean flag preserves the AI-assist provenance.
> 4. **AI prompts are not logged.** Only the accepted entry is logged. The natural-language prompt, the extracted OCR text, and any rejected drafts MUST NOT appear in the audit log payload — they often contain sensitive financial context and add no forensic value beyond the accepted entry.
> 5. **No AI-specific fields beyond `aiAssisted`.** Implementations MUST NOT add fields like `aiProvider`, `aiModel`, `aiConfidence`, etc. to the audit-log payload at format version 1.0. These are useful for debugging in implementation memory but are not part of the format's forensic surface.

## What does NOT change

- **Hash chain** — unchanged. The new actor value and the optional `aiAssisted` field are part of the canonical-JSON payload that gets hashed, exactly like every other actor or payload field.
- **Signing** — unchanged. AI-assisted entries are signed exactly as any other entry.
- **`origin` field** — unchanged. It stays as `window.location.origin`; cross-origin tamper detection is orthogonal to actor identity.
- **Action types** — unchanged. AI-assisted entries use the same `action` values as their manual equivalents (`invoice.post`, `purchase.post`, etc.) — there is no `invoice.post.ai` or similar.
- **`manifest.schemaVersion`** — unchanged at the standard level. The Bahi reference implementation will internally bump its `meta.schemaVersion` 9 → 10 on the books.sqlite side so older Bahi builds banner cleanly when they encounter a file containing `actor: "ai"` rows. This is a Bahi-internal book-keeping detail and does not require a `khataFormatVersion` bump in `manifest.json`.

## Backward compatibility

The change is purely additive:

- Older readers that only know `"owner" | "ca" | "system"` will see `actor: "ai"` as an unknown value. Per the existing "preserve unknown fields on read and write them back unchanged" rule, the round-trip is safe; a strict-validation reader could be relaxed to accept the four known values plus pass-through unknowns.
- Older readers that don't know `aiAssisted` will preserve it as an unknown payload field per the same rule.
- No DDL changes are required (the `actor` column in the canonical SQL DDL is already `TEXT` with no CHECK constraint).
- No hash-chain change is required — canonical JSON of a row containing `actor: "ai"` produces exactly the right bytes; verification is unaffected.

## Out of scope for this PR

Considered and deliberately left for future work:

- A separate `aiProvider` / `aiModel` / `aiConfidence` triple in the payload — useful for debugging but a leak surface and a maintenance burden in the format. Out.
- A new `actor: "system+ai"` or similar composite — collapses cleanly into the four-value enum once you accept that AI never acts alone. Out.
- Logging the AI prompt text or the rejected drafts — privacy concern. Explicitly forbidden in §5 of the new subsection.

## Asks

1. Pick the wording you like — happy to revise any of the above.
2. Decide whether the new "AI-assisted entries" subsection is worth its weight in the spec, or whether the inline notes on `actor` and `aiAssisted` are enough.
3. If you'd rather see this as a `khataFormatVersion` 1.0 → 1.1 bump (instead of purely additive at 1.0), I can rework. My read is that "additive at 1.0" is fine because the field set is already documented as "expect field additions in the minor version range" in the manifest schema description, but happy to follow whatever signal you prefer.

No urgency — Bahi's Smart Capture v1.1.0 build will run against the proposed shape and reconcile to whatever you accept before the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)